### PR TITLE
Update Main Menu

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,10 +1,10 @@
 # Documentation Categories
 
-- <span style="font-size: 150%">[Using ClassicPress](https://docs.classicpress.net/using-classicpress/)</span>
+
 - <span style="font-size: 150%">[Installing ClassicPress](https://docs.classicpress.net/installing-classicpress/)</span>
+- <span style="font-size: 150%">[Using ClassicPress](https://docs.classicpress.net/using-classicpress/)</span>
+- - <span style="font-size: 150%">[Developing with ClassicPress](https://docs.classicpress.net/developing-with-classicpress/)</span>
 - <span style="font-size: 150%">[Testing ClassicPress](https://docs.classicpress.net/testing-classicpress/)</span>
-- <span style="font-size: 150%">[Developing ClassicPress](https://docs.classicpress.net/developing-classicpress/)</span>
 - <span style="font-size: 150%">[FAQ and Support](https://docs.classicpress.net/faq-support/)</span>
-- <span style="font-size: 150%">[Brand Guidelines](https://www.classicpress.net/brand-guidelines/)</span>
 
 Or [go back to the main ClassicPress site](https://www.classicpress.net).


### PR DESCRIPTION
First, we _install_ ClassicPress.
Then, we _use_ it.
Then we develop with it.
Perhaps, we want to test it.
We may have Faqs.

I think all the rest should not be on this page.
Maybe, we may want to Develop _with_ ClassicPress, thus, add a link to a subpage where:
- developer documentation (code generated Codex) is linked.
- more advanced developer oriented docs such as Security Page, etc.

The contents of _Developing ClassicPress_ should be in the "Contributors" menu page > https://www.classicpress.net/contributors/ or in https://www.classicpress.net/community/ and likely not be linked here. 
It is not telling us "how to". 
It just tells us that you may help and that changes go thru a poll/vote. But it wont help neither a user or a developer to actually achieve something with CP.

Brand Guidelines should, again, not be in a User Doc. They are already in the main site and that is enough.